### PR TITLE
feat: mega menu & cleaned home layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -19,14 +19,6 @@
   <link href="/assets/css/styles.css" rel="stylesheet" />
 </head>
 <body class="bg-neutral-950 text-neutral-100 font-sans">
-  <div class="w-full bg-emerald-500/10 border-b border-emerald-400/20 text-emerald-200 text-center text-sm py-2" data-i18n="announcement">Consent-only, public-view audits. Educational. You stay in control.</div>
-  <div class="w-full border-b border-white/10 bg-white/5">
-    <div class="mx-auto max-w-6xl px-4 py-2 text-xs text-white/70 flex items-center gap-2">
-      <span class="inline-flex h-2 w-2 rounded-full bg-emerald-400"></span>
-      <span class="font-semibold" data-i18n="ribbon.title">Manual Audit Promise:</span>
-      <span data-i18n="ribbon.copy">No bots, no scraping, no API. Every audit is performed by a human, reviewing only what’s publicly visible.</span>
-    </div>
-  </div>
   <div id="sra-header"></div>
 
   <main id="main">

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -22,3 +22,8 @@ html[dir="rtl"] .text-left { text-align: right; }
 html[dir="rtl"] .text-right { text-align: left; }
 /* Flip common gap/padding nuances only if needed; Tailwind handles most layout well in RTL. */
 /* Optional: tweak FAQ summary arrow if you added icons, not needed now. */
+
+/* Mega menu transitions */
+#megaPanel { transition: opacity .15s ease; }
+#megaPanel[data-open="true"] { opacity: 1; }
+#megaPanel.hidden { opacity: 0; }

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -12,11 +12,6 @@ export async function sraInit(activePage) {
   });
   await i18n.init();
 
-  // mobile menu
-  const menuBtn = document.getElementById('menuBtn');
-  const mobileMenu = document.getElementById('mobileMenu');
-  if (menuBtn && mobileMenu) menuBtn.addEventListener('click', () => mobileMenu.classList.toggle('hidden'));
-
   // theme toggle
   const themeToggle = document.getElementById('themeToggle');
   if (themeToggle) {
@@ -53,9 +48,67 @@ export async function sraInit(activePage) {
   setHref('ctaStartStandard', LINKS.intake);
   setHref('ctaStartDeep', LINKS.message);
   setHref('ctaStartBottom', LINKS.intake);
-  setHref('ctaMessageEstimator', LINKS.message);
-  setHref('ctaStartEstimator', LINKS.intake);
   setHref('ctaMessageAbout', LINKS.message);
+
+  // ----- Mega Menu (desktop) -----
+  const megaBtn = document.getElementById('megaBtn');
+  const megaPanel = document.getElementById('megaPanel');
+  let megaTimer;
+
+  function openMega() {
+    if (!megaPanel) return;
+    megaPanel.classList.remove('hidden');
+    megaPanel.setAttribute('data-open','true');
+    megaBtn?.setAttribute('aria-expanded','true');
+  }
+  function closeMega() {
+    if (!megaPanel) return;
+    megaPanel.classList.add('hidden');
+    megaPanel.removeAttribute('data-open');
+    megaBtn?.setAttribute('aria-expanded','false');
+  }
+  function toggleMega() {
+    if (!megaPanel) return;
+    if (megaPanel.classList.contains('hidden')) openMega(); else closeMega();
+  }
+
+  // Click to open/close
+  megaBtn?.addEventListener('click', (e)=>{ e.preventDefault(); toggleMega(); });
+
+  // Hover open/close for pointer devices
+  const headerEl = document.querySelector('header');
+  if (headerEl && window.matchMedia('(pointer:fine)').matches) {
+    headerEl.addEventListener('mouseenter', ()=>{ clearTimeout(megaTimer); openMega(); });
+    headerEl.addEventListener('mouseleave', ()=>{ megaTimer = setTimeout(closeMega, 120); });
+  }
+
+  // Close on outside click / ESC
+  document.addEventListener('click', (e)=>{
+    if (!megaPanel || !megaBtn) return;
+    const within = megaPanel.contains(e.target) || megaBtn.contains(e.target);
+    if (!within) closeMega();
+  });
+  document.addEventListener('keydown', (e)=>{ if (e.key === 'Escape') closeMega(); });
+
+  // Wire "Message" link inside mega
+  setHref('ctaMessageTopMega', LINKS.message);
+
+  // ----- Mobile hamburger -----
+  const hamburgerBtn = document.getElementById('hamburgerBtn');
+  const mobileMenuEl = document.getElementById('mobileMenu');
+  hamburgerBtn?.addEventListener('click', ()=>{
+    mobileMenuEl?.classList.toggle('hidden');
+  });
+
+  // Mobile theme toggle mirrors desktop
+  const themeToggleMobile = document.getElementById('themeToggleMobile');
+  if (themeToggleMobile) {
+    themeToggleMobile.addEventListener('click', ()=>{
+      const html = document.documentElement;
+      html.classList.toggle('dark');
+      localStorage.setItem('theme', html.classList.contains('dark') ? 'dark' : 'light');
+    });
+  }
 }
 
 export function initTabs() {

--- a/contact.html
+++ b/contact.html
@@ -19,14 +19,6 @@
   <link href="/assets/css/styles.css" rel="stylesheet" />
 </head>
 <body class="bg-neutral-950 text-neutral-100 font-sans">
-  <div class="w-full bg-emerald-500/10 border-b border-emerald-400/20 text-emerald-200 text-center text-sm py-2" data-i18n="announcement">Consent-only, public-view audits. Educational. You stay in control.</div>
-  <div class="w-full border-b border-white/10 bg-white/5">
-    <div class="mx-auto max-w-6xl px-4 py-2 text-xs text-white/70 flex items-center gap-2">
-      <span class="inline-flex h-2 w-2 rounded-full bg-emerald-400"></span>
-      <span class="font-semibold" data-i18n="ribbon.title">Manual Audit Promise:</span>
-      <span data-i18n="ribbon.copy">No bots, no scraping, no API. Every audit is performed by a human, reviewing only what’s publicly visible.</span>
-    </div>
-  </div>
   <div id="sra-header"></div>
 
   <main id="main">
@@ -34,7 +26,7 @@
       <h1 class="text-4xl font-extrabold" data-i18n="nav.contact">Start here</h1>
       <p class="mt-4 text-white/70">Consent-only, human-performed audits. Message me first if you have questions, or go straight to the intake form when ready.</p>
       <div class="mt-8 flex flex-col sm:flex-row gap-3 justify-center">
-        <a id="ctaMessageTop" href="#" class="rounded-xl border border-white/20 px-5 py-3 font-semibold hover:bg-white/10" data-i18n="cta.message">Message me first</a>
+        <a id="ctaMessageHero" href="#" class="rounded-xl border border-white/20 px-5 py-3 font-semibold hover:bg-white/10" data-i18n="cta.message">Message me first</a>
         <a id="ctaStartHero" href="#" class="rounded-xl bg-emerald-500 px-5 py-3 font-semibold text-neutral-900 hover:bg-emerald-400" data-i18n="cta.start">Start my audit</a>
       </div>
     </section>

--- a/ethics.html
+++ b/ethics.html
@@ -19,14 +19,6 @@
   <link href="/assets/css/styles.css" rel="stylesheet" />
 </head>
 <body class="bg-neutral-950 text-neutral-100 font-sans">
-  <div class="w-full bg-emerald-500/10 border-b border-emerald-400/20 text-emerald-200 text-center text-sm py-2" data-i18n="announcement">Consent-only, public-view audits. Educational. You stay in control.</div>
-  <div class="w-full border-b border-white/10 bg-white/5">
-    <div class="mx-auto max-w-6xl px-4 py-2 text-xs text-white/70 flex items-center gap-2">
-      <span class="inline-flex h-2 w-2 rounded-full bg-emerald-400"></span>
-      <span class="font-semibold" data-i18n="ribbon.title">Manual Audit Promise:</span>
-      <span data-i18n="ribbon.copy">No bots, no scraping, no API. Every audit is performed by a human, reviewing only what’s publicly visible.</span>
-    </div>
-  </div>
   <div id="sra-header"></div>
 
   <main id="main">

--- a/faq.html
+++ b/faq.html
@@ -19,14 +19,6 @@
   <link href="/assets/css/styles.css" rel="stylesheet" />
 </head>
 <body class="bg-neutral-950 text-neutral-100 font-sans">
-  <div class="w-full bg-emerald-500/10 border-b border-emerald-400/20 text-emerald-200 text-center text-sm py-2" data-i18n="announcement">Consent-only, public-view audits. Educational. You stay in control.</div>
-  <div class="w-full border-b border-white/10 bg-white/5">
-    <div class="mx-auto max-w-6xl px-4 py-2 text-xs text-white/70 flex items-center gap-2">
-      <span class="inline-flex h-2 w-2 rounded-full bg-emerald-400"></span>
-      <span class="font-semibold" data-i18n="ribbon.title">Manual Audit Promise:</span>
-      <span data-i18n="ribbon.copy">No bots, no scraping, no API. Every audit is performed by a human, reviewing only what’s publicly visible.</span>
-    </div>
-  </div>
   <div id="sra-header"></div>
 
   <main id="main">

--- a/how.html
+++ b/how.html
@@ -19,14 +19,6 @@
   <link href="/assets/css/styles.css" rel="stylesheet" />
 </head>
 <body class="bg-neutral-950 text-neutral-100 font-sans">
-  <div class="w-full bg-emerald-500/10 border-b border-emerald-400/20 text-emerald-200 text-center text-sm py-2" data-i18n="announcement">Consent-only, public-view audits. Educational. You stay in control.</div>
-  <div class="w-full border-b border-white/10 bg-white/5">
-    <div class="mx-auto max-w-6xl px-4 py-2 text-xs text-white/70 flex items-center gap-2">
-      <span class="inline-flex h-2 w-2 rounded-full bg-emerald-400"></span>
-      <span class="font-semibold" data-i18n="ribbon.title">Manual Audit Promise:</span>
-      <span data-i18n="ribbon.copy">No bots, no scraping, no API. Every audit is performed by a human, reviewing only what’s publicly visible.</span>
-    </div>
-  </div>
   <div id="sra-header"></div>
 
   <main id="main">

--- a/index.html
+++ b/index.html
@@ -26,141 +26,39 @@
   <link href="/assets/css/styles.css" rel="stylesheet" />
 </head>
 <body class="bg-neutral-950 text-neutral-100 font-sans">
-  <a href="#main" class="absolute left-2 top-2 z-[100] rounded-md bg-white/10 px-2 py-1 text-xs backdrop-blur hover:bg-white/20 focus:outline-none focus:ring">Skip to content</a>
-
-  <div class="w-full bg-emerald-500/10 border-b border-emerald-400/20 text-emerald-200 text-center text-sm py-2" data-i18n="announcement">Consent-only, public-view audits. Educational. You stay in control.</div>
-  <div class="w-full border-b border-white/10 bg-white/5">
-    <div class="mx-auto max-w-6xl px-4 py-2 text-xs text-white/70 flex items-center gap-2">
-      <span class="inline-flex h-2 w-2 rounded-full bg-emerald-400"></span>
-      <span class="font-semibold" data-i18n="ribbon.title">Manual Audit Promise:</span>
-      <span data-i18n="ribbon.copy">No bots, no scraping, no API. Every audit is performed by a human, reviewing only what’s publicly visible.</span>
-    </div>
-  </div>
   <div id="sra-header"></div>
 
-  <!-- Hero -->
-  <section class="relative overflow-hidden">
-    <div class="absolute inset-0 -z-10 bg-[radial-gradient(ellipse_at_top,_var(--tw-gradient-stops))] from-emerald-600/20 via-neutral-900 to-neutral-950"></div>
-    <div class="mx-auto max-w-6xl px-4 py-16 md:py-24">
-      <div class="max-w-2xl">
-        <h1 class="text-4xl md:text-6xl font-extrabold leading-tight" data-i18n="hero.title">See your Facebook the way a stranger does.</h1>
-        <p class="mt-4 text-lg text-white/70" data-i18n="hero.subtitle">We run an independent, consent-only exposure audit of your public Facebook. You’ll see what’s visible, how it could be misused, and what options you have. You stay in control.</p>
-        <div class="mt-8 flex flex-col sm:flex-row gap-3">
-          <a id="ctaStartHero" href="#" class="inline-flex items-center justify-center rounded-xl bg-white px-5 py-3 font-semibold text-neutral-900 hover:bg-white/90" data-i18n="cta.start">Start my audit</a>
-          <a id="ctaMessageHero" href="#" class="inline-flex items-center justify-center rounded-xl border border-white/20 px-5 py-3 font-semibold hover:bg-white/10" data-i18n="cta.message">Message me first</a>
-        </div>
-        <div class="mt-6 rounded-xl border border-white/10 bg-white/5 p-4">
-          <div class="flex items-start gap-3">
-            <div class="mt-1 h-3 w-3 rounded-full bg-emerald-400"></div>
-            <div>
-              <p class="text-sm text-white/80" data-i18n="manual.card.lead"><span class="font-semibold">Manual, not AI:</span> I personally review posts, photos, comments, and visible profile fields. No logins, no friend requests, no bypassing privacy.</p>
-              <p class="mt-2 text-xs text-white/50" data-i18n="manual.card.note">Effort depends on how much you’ve posted—3 posts in 12 months vs. 300 is a different scope. The estimator below helps set expectations.</p>
-            </div>
-          </div>
-        </div>
-        <p class="mt-3 text-xs text-white/50" data-i18n="hero.badges">No logins. No friend requests. Public-view only. Evidence-based.</p>
-      </div>
-    </div>
-  </section>
-
   <main id="main">
-    <!-- Tabs: Summary / Details -->
-    <section class="mx-auto max-w-6xl px-4 pt-6">
-      <div class="inline-flex rounded-xl border border-white/10 bg-white/5 p-1" role="tablist" aria-label="View mode">
-        <button class="sra-tab sra-tab-active rounded-lg px-4 py-2 text-sm font-semibold" data-tab="summary" role="tab" aria-selected="true" data-i18n="tabs.summary">Summary</button>
-        <button class="sra-tab rounded-lg px-4 py-2 text-sm font-semibold text-white/70 hover:text-white" data-tab="details" role="tab" aria-selected="false" data-i18n="tabs.details">Details</button>
-      </div>
-    </section>
-
-    <!-- SUMMARY PANEL -->
-    <section id="tab-summary" data-tab-panel="summary" class="mx-auto max-w-6xl px-4 py-10">
-      <div class="grid gap-6 md:grid-cols-3">
-        <div class="rounded-2xl border border-white/10 bg-white/5 p-6">
-          <h3 class="font-bold" data-i18n="summary.clarity.h">Clarity</h3>
-          <p class="mt-2 text-white/70" data-i18n="summary.clarity.p">See your Facebook exactly as a stranger would. No surprises.</p>
-        </div>
-        <div class="rounded-2xl border border-white/10 bg-white/5 p-6">
-          <h3 class="font-bold" data-i18n="summary.control.h">Control</h3>
-          <p class="mt-2 text-white/70" data-i18n="summary.control.p">You decide what to keep public or change. I don’t prescribe.</p>
-        </div>
-        <div class="rounded-2xl border border-white/10 bg-white/5 p-6">
-          <h3 class="font-bold" data-i18n="summary.proof.h">Proof</h3>
-          <p class="mt-2 text-white/70" data-i18n="summary.proof.p">Every finding is documented with screenshots so you can verify.</p>
+    <section class="mx-auto max-w-6xl px-4 py-16 md:py-24">
+      <div class="max-w-2xl">
+        <h1 class="text-4xl md:text-6xl font-extrabold leading-tight">See your Facebook the way a stranger does.</h1>
+        <p class="mt-4 text-lg text-white/70">Independent, consent-only exposure audit of your public Facebook. Human performed. You choose what to change.</p>
+        <div class="mt-8 flex flex-col sm:flex-row gap-3">
+          <a id="ctaStartHero" href="#" class="inline-flex items-center justify-center rounded-xl bg-white px-5 py-3 font-semibold text-neutral-900 hover:bg-white/90">Start my audit</a>
+          <a id="ctaMessageHero" href="#" class="inline-flex items-center justify-center rounded-xl border border-white/20 px-5 py-3 font-semibold hover:bg-white/10">Message me first</a>
         </div>
       </div>
 
-      <div class="mt-8 rounded-2xl border border-emerald-400/30 bg-emerald-500/5 p-6 md:p-8">
-        <h2 class="text-2xl font-extrabold" data-i18n="est.title">Scope Estimator</h2>
-        <p class="mt-2 text-white/70 text-sm" data-i18n="est.desc">A quick way to set expectations. This isn’t automated scanning—it’s a manual review. Estimates help match effort to your goals.</p>
-        <form id="estimatorForm" class="mt-6 grid gap-6 md:grid-cols-2" onsubmit="return false;">
-          <div>
-            <label for="timeframe" class="block text-sm font-semibold" data-i18n="est.timeframe">Timeframe</label>
-            <select id="timeframe" class="sra-input mt-2">
-              <option value="12" data-i18n="est.tf.12">Last 12 months</option>
-              <option value="48" data-i18n="est.tf.48">Last 3–4 years</option>
-              <option value="180" data-i18n="est.tf.180">Full history (approx.)</option>
-            </select>
-            <p class="mt-2 text-xs text-white/50">Choose how far back you want me to look.</p>
-          </div>
-          <div>
-            <label for="postsPerWeek" class="block text-sm font-semibold" data-i18n="est.ppw">Average posts per week</label>
-            <input id="postsPerWeek" type="range" min="0" max="14" step="1" value="2" class="mt-2 w-full" />
-            <div class="mt-1 text-xs text-white/50"><span id="ppwOut">2</span> posts/week (estimate)</div>
-          </div>
-          <div>
-            <label for="taggedFreq" class="block text-sm font-semibold" data-i18n="est.tagged">Tagged posts frequency</label>
-            <input id="taggedFreq" type="range" min="0" max="10" step="1" value="1" class="mt-2 w-full" />
-            <div class="mt-1 text-xs text-white/50"><span id="taggedOut">1</span> per week (estimate)</div>
-          </div>
-          <div>
-            <label for="commentsPerPost" class="block text-sm font-semibold" data-i18n="est.cpp">Typical comments per post</label>
-            <input id="commentsPerPost" type="range" min="0" max="50" step="1" value="5" class="mt-2 w-full" />
-            <div class="mt-1 text-xs text-white/50"><span id="cppOut">5</span> comments/post (estimate)</div>
-          </div>
-          <div>
-            <label for="groupsEvents" class="block text-sm font-semibold" data-i18n="est.ge">Active groups/events</label>
-            <input id="groupsEvents" type="range" min="0" max="50" step="1" value="5" class="mt-2 w-full" />
-            <div class="mt-1 text-xs text-white/50"><span id="geOut">5</span> active (estimate)</div>
-          </div>
-          <div>
-            <label for="albums" class="block text-sm font-semibold" data-i18n="est.alb">Photo albums to scan</label>
-            <input id="albums" type="range" min="0" max="50" step="1" value="3" class="mt-2 w-full" />
-            <div class="mt-1 text-xs text-white/50"><span id="albOut">3</span> albums (estimate)</div>
-          </div>
-        </form>
-        <div class="mt-6 grid gap-6 md:grid-cols-3">
-          <div class="rounded-xl border border-white/10 bg-white/5 p-4">
-            <div class="text-sm text-white/50" data-i18n="est.items">Estimated items to review</div>
-            <div id="estItems" class="mt-1 text-2xl font-extrabold">—</div>
-          </div>
-          <div class="rounded-xl border border-white/10 bg-white/5 p-4">
-            <div class="text-sm text-white/50" data-i18n="est.effort">Effort band (manual)</div>
-            <div id="estEffort" class="mt-1 text-2xl font-extrabold">—</div>
-            <div class="mt-1 text-xs text-white/50">Varies with complexity; final scope confirmed after a brief chat.</div>
-          </div>
-          <div class="rounded-xl border border-white/10 bg-white/5 p-4">
-            <div class="text-sm text-white/50" data-i18n="est.package">Suggested package</div>
-            <div id="estPackage" class="mt-1 text-2xl font-extrabold">—</div>
-            <div class="mt-1 text-xs text-white/50">You can always upgrade or narrow focus.</div>
-          </div>
-        </div>
-        <div class="mt-6 flex flex-col sm:flex-row gap-3">
-          <a id="ctaMessageEstimator" href="#" class="inline-flex items-center justify-center rounded-xl border border-white/20 px-5 py-3 font-semibold hover:bg-white/10" data-i18n="cta.message">Message me first</a>
-          <a id="ctaStartEstimator" href="#" class="inline-flex items-center justify-center rounded-xl bg-emerald-500 px-5 py-3 font-semibold text-neutral-900 hover:bg-emerald-400" data-i18n="cta.start">Start my audit</a>
-        </div>
-        <p class="mt-3 text-xs text-white/50" data-i18n="est.note">These are non-binding estimates to aid planning. All audits are human-performed using only public information.</p>
-      </div>
-    </section>
-
-    <!-- DETAILS PANEL -->
-    <section id="tab-details" data-tab-panel="details" class="hidden mx-auto max-w-6xl px-4 py-10">
-      <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        <a href="/how.html" class="block rounded-2xl border border-white/10 bg-white/5 p-6 hover:bg-white/10" data-nav="how"><h3 class="font-bold" data-i18n="nav.how">How it works</h3></a>
-        <a href="/what-you-get.html" class="block rounded-2xl border border-white/10 bg-white/5 p-6 hover:bg-white/10" data-nav="deliverables"><h3 class="font-bold" data-i18n="nav.deliverables">What you get</h3></a>
-        <a href="/packages.html" class="block rounded-2xl border border-white/10 bg-white/5 p-6 hover:bg-white/10" data-nav="packages"><h3 class="font-bold" data-i18n="nav.packages">Packages</h3></a>
-        <a href="/ethics.html" class="block rounded-2xl border border-white/10 bg-white/5 p-6 hover:bg-white/10" data-nav="ethics"><h3 class="font-bold" data-i18n="nav.ethics">Ethics</h3></a>
-        <a href="/faq.html" class="block rounded-2xl border border-white/10 bg-white/5 p-6 hover:bg-white/10" data-nav="faq"><h3 class="font-bold" data-i18n="nav.faq">FAQ</h3></a>
-        <a href="/about.html" class="block rounded-2xl border border-white/10 bg-white/5 p-6 hover:bg-white/10" data-nav="about"><h3 class="font-bold" data-i18n="nav.about">About</h3></a>
+      <!-- Quick nav tiles -->
+      <div class="mt-14 grid gap-6 md:grid-cols-3">
+        <a href="/how.html" class="rounded-2xl border border-white/10 bg-white/5 p-6 hover:bg-white/10 transition">
+          <h3 class="text-xl font-bold">How it works</h3><p class="mt-2 text-white/70">The DARK process, step-by-step.</p>
+        </a>
+        <a href="/what-you-get.html" class="rounded-2xl border border-white/10 bg-white/5 p-6 hover:bg-white/10 transition">
+          <h3 class="text-xl font-bold">What you get</h3><p class="mt-2 text-white/70">Report, evidence, and guides.</p>
+        </a>
+        <a href="/packages.html" class="rounded-2xl border border-white/10 bg-white/5 p-6 hover:bg-white/10 transition">
+          <h3 class="text-xl font-bold">Packages</h3><p class="mt-2 text-white/70">Choose depth; add pivots.</p>
+        </a>
+        <a href="/ethics.html" class="rounded-2xl border border-white/10 bg-white/5 p-6 hover:bg-white/10 transition">
+          <h3 class="text-xl font-bold">Ethics</h3><p class="mt-2 text-white/70">Consent-only, public-view.</p>
+        </a>
+        <a href="/faq.html" class="rounded-2xl border border-white/10 bg-white/5 p-6 hover:bg-white/10 transition">
+          <h3 class="text-xl font-bold">FAQ</h3><p class="mt-2 text-white/70">Straight answers.</p>
+        </a>
+        <a href="/about.html" class="rounded-2xl border border-white/10 bg-white/5 p-6 hover:bg-white/10 transition">
+          <h3 class="text-xl font-bold">About</h3><p class="mt-2 text-white/70">Who I am and why I care.</p>
+        </a>
       </div>
     </section>
   </main>
@@ -172,10 +70,8 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="/assets/js/i18n.js"></script>
   <script type="module">
-    import { sraInit, initTabs, initEstimator } from '/assets/js/main.js';
+    import { sraInit } from '/assets/js/main.js';
     await sraInit('home');
-    initTabs();
-    initEstimator();
   </script>
 </body>
 </html>

--- a/packages.html
+++ b/packages.html
@@ -19,14 +19,6 @@
   <link href="/assets/css/styles.css" rel="stylesheet" />
 </head>
 <body class="bg-neutral-950 text-neutral-100 font-sans">
-  <div class="w-full bg-emerald-500/10 border-b border-emerald-400/20 text-emerald-200 text-center text-sm py-2" data-i18n="announcement">Consent-only, public-view audits. Educational. You stay in control.</div>
-  <div class="w-full border-b border-white/10 bg-white/5">
-    <div class="mx-auto max-w-6xl px-4 py-2 text-xs text-white/70 flex items-center gap-2">
-      <span class="inline-flex h-2 w-2 rounded-full bg-emerald-400"></span>
-      <span class="font-semibold" data-i18n="ribbon.title">Manual Audit Promise:</span>
-      <span data-i18n="ribbon.copy">No bots, no scraping, no API. Every audit is performed by a human, reviewing only what’s publicly visible.</span>
-    </div>
-  </div>
   <div id="sra-header"></div>
 
   <main id="main">

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,36 +1,94 @@
-<!-- Shared Header/Nav -->
 <header class="sticky top-0 z-50 border-b border-white/10 bg-neutral-950/80 backdrop-blur">
   <div class="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
     <a href="/" class="flex items-center gap-3">
       <img src="/assets/images/no background white.png" alt="Social Risk Audit logo" class="h-8 w-auto" />
       <span class="text-lg font-extrabold tracking-tight">Social Risk Audit</span>
     </a>
-    <nav class="hidden md:flex items-center gap-6 text-sm">
-      <a data-i18n="nav.home" href="/" class="hover:text-white/70" data-nav="home">Home</a>
-      <a data-i18n="nav.how" href="/how.html" class="hover:text-white/70" data-nav="how">How it works</a>
-      <a data-i18n="nav.deliverables" href="/what-you-get.html" class="hover:text-white/70" data-nav="deliverables">What you get</a>
-      <a data-i18n="nav.packages" href="/packages.html" class="hover:text-white/70" data-nav="packages">Packages</a>
-      <a data-i18n="nav.ethics" href="/ethics.html" class="hover:text-white/70" data-nav="ethics">Ethics</a>
-      <a data-i18n="nav.faq" href="/faq.html" class="hover:text-white/70" data-nav="faq">FAQ</a>
-      <a data-i18n="nav.about" href="/about.html" class="hover:text-white/70" data-nav="about">About</a>
-      <a data-i18n="nav.contact" href="/contact.html" class="hover:text-white/70" data-nav="contact">Contact</a>
+
+    <!-- Desktop controls -->
+    <div class="hidden md:flex items-center gap-2">
+      <button id="megaBtn" class="rounded-lg border border-white/10 px-3 py-1 hover:bg-white/10" aria-haspopup="true" aria-expanded="false">Menu</button>
+      <a id="ctaMessageTop" href="#" class="rounded-lg bg-emerald-500 px-4 py-2 font-semibold text-neutral-900 hover:bg-emerald-400">Message me first</a>
       <button id="langToggle" class="rounded-lg border border-white/10 px-3 py-1 hover:bg-white/10" aria-label="Toggle language">EN/HE</button>
-      <button id="themeToggle" class="rounded-lg border border-white/10 px-3 py-1 hover:bg-white/10"><span data-i18n="nav.theme">Theme</span></button>
-      <a id="ctaMessageTop" href="#" class="rounded-lg bg-emerald-500 px-4 py-2 font-semibold text-neutral-900 hover:bg-emerald-400" data-i18n="cta.message">Message me first</a>
-    </nav>
-    <button id="menuBtn" class="md:hidden rounded-lg border border-white/10 px-3 py-1">Menu</button>
+      <button id="themeToggle" class="rounded-lg border border-white/10 px-3 py-1 hover:bg-white/10">Theme</button>
+    </div>
+
+    <!-- Mobile hamburger -->
+    <button id="hamburgerBtn" class="md:hidden rounded-lg border border-white/10 px-3 py-1" aria-label="Open menu">☰</button>
   </div>
-  <div id="mobileMenu" class="hidden border-t border-white/10 md:hidden">
-    <div class="mx-auto max-w-6xl px-4 py-3 space-y-2">
-      <a data-i18n="nav.home" href="/" class="block" data-nav="home">Home</a>
-      <a data-i18n="nav.how" href="/how.html" class="block" data-nav="how">How it works</a>
-      <a data-i18n="nav.deliverables" href="/what-you-get.html" class="block" data-nav="deliverables">What you get</a>
-      <a data-i18n="nav.packages" href="/packages.html" class="block" data-nav="packages">Packages</a>
-      <a data-i18n="nav.ethics" href="/ethics.html" class="block" data-nav="ethics">Ethics</a>
-      <a data-i18n="nav.faq" href="/faq.html" class="block" data-nav="faq">FAQ</a>
-      <a data-i18n="nav.about" href="/about.html" class="block" data-nav="about">About</a>
-      <a data-i18n="nav.contact" href="/contact.html" class="block" data-nav="contact">Contact</a>
-      <button id="langToggleMobile" class="mt-2 inline-block rounded-lg border border-white/10 px-4 py-2">EN/HE</button>
+
+  <!-- Mega Menu panel (desktop) -->
+  <div id="megaPanel" class="hidden border-t border-white/10 bg-neutral-950/95 backdrop-blur">
+    <div class="mx-auto max-w-6xl px-4 py-8 grid md:grid-cols-3 gap-8">
+      <div>
+        <h3 class="text-sm uppercase text-white/50">Audit</h3>
+        <ul class="mt-3 space-y-2">
+          <li><a href="/how.html" class="block rounded-lg p-3 hover:bg-white/5">
+            <div class="font-semibold">How it works</div>
+            <div class="text-sm text-white/70">Discover → Analyze → Reduce → Keep Safe</div>
+          </a></li>
+          <li><a href="/what-you-get.html" class="block rounded-lg p-3 hover:bg-white/5">
+            <div class="font-semibold">What you get</div>
+            <div class="text-sm text-white/70">Report, screenshots, and guides</div>
+          </a></li>
+          <li><a href="/packages.html" class="block rounded-lg p-3 hover:bg-white/5">
+            <div class="font-semibold">Packages</div>
+            <div class="text-sm text-white/70">Quick Check, Standard, Deep Dive</div>
+          </a></li>
+        </ul>
+      </div>
+
+      <div>
+        <h3 class="text-sm uppercase text-white/50">Trust & Ethics</h3>
+        <ul class="mt-3 space-y-2">
+          <li><a href="/ethics.html" class="block rounded-lg p-3 hover:bg-white/5">
+            <div class="font-semibold">Ethics</div>
+            <div class="text-sm text-white/70">Consent-only, public-view audits</div>
+          </a></li>
+          <li><a href="/faq.html" class="block rounded-lg p-3 hover:bg-white/5">
+            <div class="font-semibold">FAQ</div>
+            <div class="text-sm text-white/70">No passwords, no friending, no bypassing privacy</div>
+          </a></li>
+          <li><a href="/about.html" class="block rounded-lg p-3 hover:bg-white/5">
+            <div class="font-semibold">About</div>
+            <div class="text-sm text-white/70">Background & privacy stance</div>
+          </a></li>
+        </ul>
+      </div>
+
+      <div>
+        <h3 class="text-sm uppercase text-white/50">Get in touch</h3>
+        <ul class="mt-3 space-y-2">
+          <li><a href="/contact.html" class="block rounded-lg p-3 hover:bg-white/5">
+            <div class="font-semibold">Contact</div>
+            <div class="text-sm text-white/70">How to start and what to expect</div>
+          </a></li>
+          <li><a id="ctaMessageTopMega" href="#" class="block rounded-lg p-3 bg-emerald-500/10 hover:bg-emerald-500/20">
+            <div class="font-semibold">Message me first</div>
+            <div class="text-sm text-white/70">WhatsApp Business</div>
+          </a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <!-- Mobile menu -->
+  <div id="mobileMenu" class="hidden border-t border-white/10 md:hidden bg-neutral-950">
+    <div class="mx-auto max-w-6xl px-4 py-4 space-y-2">
+      <a href="/" class="block">Home</a>
+      <a href="/how.html" class="block">How it works</a>
+      <a href="/what-you-get.html" class="block">What you get</a>
+      <a href="/packages.html" class="block">Packages</a>
+      <a href="/ethics.html" class="block">Ethics</a>
+      <a href="/faq.html" class="block">FAQ</a>
+      <a href="/about.html" class="block">About</a>
+      <a href="/contact.html" class="block">Contact</a>
+      <div class="pt-2 flex items-center gap-2">
+        <button id="langToggleMobile" class="rounded-lg border border-white/10 px-3 py-1">EN/HE</button>
+        <button id="themeToggleMobile" class="rounded-lg border border-white/10 px-3 py-1">Theme</button>
+        <a id="ctaMessageTopMobile" href="#" class="ml-auto rounded-lg bg-emerald-500 px-4 py-2 font-semibold text-neutral-900 hover:bg-emerald-400">Message</a>
+      </div>
     </div>
   </div>
 </header>
+

--- a/what-you-get.html
+++ b/what-you-get.html
@@ -19,14 +19,6 @@
   <link href="/assets/css/styles.css" rel="stylesheet" />
 </head>
 <body class="bg-neutral-950 text-neutral-100 font-sans">
-  <div class="w-full bg-emerald-500/10 border-b border-emerald-400/20 text-emerald-200 text-center text-sm py-2" data-i18n="announcement">Consent-only, public-view audits. Educational. You stay in control.</div>
-  <div class="w-full border-b border-white/10 bg-white/5">
-    <div class="mx-auto max-w-6xl px-4 py-2 text-xs text-white/70 flex items-center gap-2">
-      <span class="inline-flex h-2 w-2 rounded-full bg-emerald-400"></span>
-      <span class="font-semibold" data-i18n="ribbon.title">Manual Audit Promise:</span>
-      <span data-i18n="ribbon.copy">No bots, no scraping, no API. Every audit is performed by a human, reviewing only what’s publicly visible.</span>
-    </div>
-  </div>
   <div id="sra-header"></div>
 
   <main id="main">


### PR DESCRIPTION
## Summary
- drop skip link, announcement bar, manual audit ribbon, tabs and estimator
- add desktop mega menu and mobile hamburger navigation
- simplify home page with hero and quick nav tiles and ensure all pages mount header/footer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc803e2c5483239e3e3ca572a01a84