### PR TITLE
Install bilingual slider (EN↔עברית) site-wide: header+mobile, persistence, RTL, optional i18n sync

### DIFF
--- a/about.html
+++ b/about.html
@@ -68,6 +68,7 @@
 
   <div id="sra-footer"></div>
 
+  <script defer src="/assets/js/lang-toggle.js"></script>
   <script type="module">
     import { sraInit } from '/assets/js/main.js';
     await sraInit('about');

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -27,3 +27,38 @@ html[dir="rtl"] .text-right { text-align: left; }
 #megaPanel { transition: opacity .15s ease; }
 #megaPanel[data-open="true"] { opacity: 1; }
 #megaPanel.hidden { opacity: 0; }
+
+/* Language toggle (dark theme) */
+.toggle-switch-container {
+  position: relative;
+  display: inline-block;
+  width: 250px;
+  height: 60px;
+  background-color: #333333;
+  border-radius: 30px;
+  cursor: pointer;
+  overflow: hidden;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+  border: 1px solid #444444;
+}
+.toggle-switch-container:hover { box-shadow: 0 6px 8px rgba(0, 0, 0, 0.3); }
+.toggle-switch-labels {
+  position: absolute; top: 0; left: 0; width: 100%; height: 100%;
+  display: flex; align-items: center; justify-content: space-around; z-index: 2;
+}
+.toggle-switch-label { font-weight: 600; font-size: 1.1rem; color: #cccccc; transition: color 0.3s ease; }
+.toggle-switch-slider {
+  position: absolute; top: 0; left: 0; width: 50%; height: 100%;
+  background-color: #ffffff; border-radius: 30px; transition: transform 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2); z-index: 1;
+}
+body.hebrew-mode .toggle-switch-slider { transform: translateX(100%); }
+body.english-mode .toggle-switch-label.en-label { color: #101010; }
+body.hebrew-mode .toggle-switch-label.he-label { color: #101010; }
+/* Compact on narrow screens */
+@media (max-width: 480px) {
+  .toggle-switch-container { width: 200px; height: 48px; }
+  .toggle-switch-label { font-size: 1rem; }
+}
+/* Ensure full RTL flip when Hebrew is active (harmless if already present) */
+html[dir="rtl"] body { direction: rtl; }

--- a/assets/js/lang-toggle.js
+++ b/assets/js/lang-toggle.js
@@ -1,0 +1,57 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // Support both desktop and mobile toggles
+  const toggles = [document.getElementById('language-toggle'), document.getElementById('language-toggle-mobile')].filter(Boolean);
+  const body = document.body;
+  const html = document.documentElement;
+
+  // User’s translation helper (data-en / data-he attributes)
+  const updateLanguage = (lang) => {
+    const elementsToTranslate = document.querySelectorAll('[data-en][data-he]');
+    elementsToTranslate.forEach(element => {
+      if (lang === 'hebrew') {
+        element.textContent = element.getAttribute('data-he');
+      } else {
+        element.textContent = element.getAttribute('data-en');
+      }
+    });
+  };
+
+  // Apply lang to HTML dir/lang + optional JSON i18n if present
+  const applyLangMeta = (lang) => {
+    html.setAttribute('lang', lang === 'hebrew' ? 'he' : 'en');
+    html.setAttribute('dir',  lang === 'hebrew' ? 'rtl' : 'ltr');
+    // Keep any JSON i18n in sync if it exists
+    if (window.__sra_i18n && typeof window.__sra_i18n.setLang === 'function') {
+      window.__sra_i18n.setLang(lang === 'hebrew' ? 'he' : 'en');
+    }
+    // Mirror key used by any earlier loader
+    localStorage.setItem('sra_lang', lang === 'hebrew' ? 'he' : 'en');
+    // ARIA state
+    toggles.forEach(t => t.setAttribute('aria-checked', lang === 'hebrew' ? 'true' : 'false'));
+  };
+
+  // Load saved preference
+  const savedLanguage = localStorage.getItem('language');
+  if (savedLanguage === 'hebrew') {
+    body.classList.add('hebrew-mode');
+    applyLangMeta('hebrew');
+    updateLanguage('hebrew');
+  } else {
+    body.classList.add('english-mode');
+    applyLangMeta('english');
+    updateLanguage('english');
+  }
+
+  // Click listeners for both toggles
+  toggles.forEach(toggleButton => {
+    toggleButton.addEventListener('click', () => {
+      const isHebrewMode = body.classList.toggle('hebrew-mode');
+      body.classList.toggle('english-mode', !isHebrewMode);
+
+      const currentLang = isHebrewMode ? 'hebrew' : 'english';
+      localStorage.setItem('language', currentLang);
+      applyLangMeta(currentLang);
+      updateLanguage(currentLang);
+    });
+  });
+});

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -11,6 +11,19 @@ export async function sraInit(activePage) {
     dictionaries: { en: '/assets/i18n/en.json', he: '/assets/i18n/he.json' }
   });
   await i18n.init();
+  window.__sra_i18n = i18n;
+
+  // Respect language chosen by the slider (if set before this script runs)
+  try {
+    const savedLanguage = localStorage.getItem('language'); // 'english' | 'hebrew'
+    if (savedLanguage === 'hebrew' && window.__sra_i18n?.setLang) {
+      window.__sra_i18n.setLang('he');
+      document.documentElement.setAttribute('lang','he');
+      document.documentElement.setAttribute('dir','rtl');
+      document.body.classList.add('hebrew-mode');
+      document.body.classList.remove('english-mode');
+    }
+  } catch (_) {}
 
   // theme toggle
   const themeToggle = document.getElementById('themeToggle');

--- a/contact.html
+++ b/contact.html
@@ -38,6 +38,7 @@
   </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="/assets/js/i18n.js"></script>
+  <script defer src="/assets/js/lang-toggle.js"></script>
   <script type="module">
     import { sraInit } from '/assets/js/main.js';
     await sraInit('contact');

--- a/ethics.html
+++ b/ethics.html
@@ -55,6 +55,7 @@
 
   <div id="sra-footer"></div>
 
+  <script defer src="/assets/js/lang-toggle.js"></script>
   <script type="module">
     import { sraInit } from '/assets/js/main.js';
     await sraInit('ethics');

--- a/how.html
+++ b/how.html
@@ -17,6 +17,7 @@
     </section>
   </main>
   <div id="sra-footer"></div>
+  <script defer src="/assets/js/lang-toggle.js"></script>
   <script type="module">
     import { sraInit } from '/assets/js/main.js';
     await sraInit('how');

--- a/index.html
+++ b/index.html
@@ -63,6 +63,7 @@
   </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="/assets/js/i18n.js"></script>
+  <script defer src="/assets/js/lang-toggle.js"></script>
   <script type="module">
     import { sraInit } from '/assets/js/main.js';
     await sraInit('home');

--- a/packages.html
+++ b/packages.html
@@ -17,6 +17,7 @@
     </section>
   </main>
   <div id="sra-footer"></div>
+  <script defer src="/assets/js/lang-toggle.js"></script>
   <script type="module">
     import { sraInit } from '/assets/js/main.js';
     await sraInit('packages');

--- a/partials/header.html
+++ b/partials/header.html
@@ -9,7 +9,14 @@
     <div class="hidden md:flex items-center gap-2">
       <button id="megaBtn" class="rounded-lg border border-white/10 px-3 py-1 hover:bg-white/10" aria-haspopup="true" aria-expanded="false">Menu</button>
       <a id="ctaMessageTop" href="#" class="rounded-lg bg-emerald-500 px-4 py-2 font-semibold text-neutral-900 hover:bg-emerald-400">Message me first</a>
-      <button id="langToggle" class="rounded-lg border border-white/10 px-3 py-1 hover:bg-white/10" aria-label="Toggle language">EN/HE</button>
+      <!-- Language Toggle (desktop) -->
+      <div id="language-toggle" class="toggle-switch-container" aria-label="Language toggle" role="switch" aria-checked="false">
+        <div class="toggle-switch-slider"></div>
+        <div class="toggle-switch-labels">
+          <span class="toggle-switch-label en-label">English</span>
+          <span class="toggle-switch-label he-label">עברית</span>
+        </div>
+      </div>
       <button id="themeToggle" class="rounded-lg border border-white/10 px-3 py-1 hover:bg-white/10">Theme</button>
     </div>
 
@@ -79,9 +86,16 @@
       <a href="/about.html" class="block">About</a>
       <a href="/contact.html" class="block">Contact</a>
       <div class="pt-2 flex items-center gap-2">
-        <button id="langToggleMobile" class="rounded-lg border border-white/10 px-3 py-1">EN/HE</button>
         <button id="themeToggleMobile" class="rounded-lg border border-white/10 px-3 py-1">Theme</button>
         <a id="ctaMessageTopMobile" href="#" class="ml-auto rounded-lg bg-emerald-500 px-4 py-2 font-semibold text-neutral-900 hover:bg-emerald-400">Message</a>
+      </div>
+      <!-- Language Toggle (mobile) -->
+      <div id="language-toggle-mobile" class="toggle-switch-container mt-3" aria-label="Language toggle" role="switch" aria-checked="false">
+        <div class="toggle-switch-slider"></div>
+        <div class="toggle-switch-labels">
+          <span class="toggle-switch-label en-label">English</span>
+          <span class="toggle-switch-label he-label">עברית</span>
+        </div>
       </div>
     </div>
   </div>

--- a/what-you-get.html
+++ b/what-you-get.html
@@ -17,6 +17,7 @@
     </section>
   </main>
   <div id="sra-footer"></div>
+  <script defer src="/assets/js/lang-toggle.js"></script>
   <script type="module">
     import { sraInit } from '/assets/js/main.js';
     await sraInit('deliverables');


### PR DESCRIPTION
## Summary
- Add bilingual language toggle component to header and mobile menu
- Style and script the toggle with localStorage persistence, RTL flipping, and optional i18n sync
- Load the toggle script on all pages and sync existing i18n to saved preference

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc88c95e2c8323981fc49053047ac6