### PR TITLE
Fix i18n/toggle init and relative asset paths

### DIFF
--- a/about.html
+++ b/about.html
@@ -68,10 +68,10 @@
 
   <div id="sra-footer"></div>
 
-  <script defer src="/assets/js/lang-toggle.js"></script>
+  <script defer src="assets/js/lang-toggle.js"></script>
   <script type="module">
-    import { sraInit } from 'assets/js/main.js';
-    await sraInit('about');
+    import { sraInit } from './assets/js/main.js';
+    (async () => { await sraInit('about'); })();
   </script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -40,8 +40,8 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="assets/js/lang-toggle.js"></script>
   <script type="module">
-    import { sraInit } from 'assets/js/main.js';
-    await sraInit('contact');
+    import { sraInit } from './assets/js/main.js';
+    (async () => { await sraInit('contact'); })();
   </script>
 </body>
 </html>

--- a/ethics.html
+++ b/ethics.html
@@ -55,10 +55,10 @@
 
   <div id="sra-footer"></div>
 
-  <script defer src="/assets/js/lang-toggle.js"></script>
+  <script defer src="assets/js/lang-toggle.js"></script>
   <script type="module">
-    import { sraInit } from 'assets/js/main.js';
-    await sraInit('ethics');
+    import { sraInit } from './assets/js/main.js';
+    (async () => { await sraInit('ethics'); })();
   </script>
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -49,9 +49,10 @@
     tailwind.config = { theme: { extend: { fontFamily: { sans: ['Inter','ui-sans-serif','system-ui']}}}};
   </script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script defer src="assets/js/lang-toggle.js"></script>
   <script type="module">
-    import { sraInit } from 'assets/js/main.js';
-    await sraInit('faq');
+    import { sraInit } from './assets/js/main.js';
+    (async () => { await sraInit('faq'); })();
   </script>
 </body>
 </html>

--- a/how.html
+++ b/how.html
@@ -17,10 +17,10 @@
     </section>
   </main>
   <div id="sra-footer"></div>
-  <script defer src="/assets/js/lang-toggle.js"></script>
+  <script defer src="assets/js/lang-toggle.js"></script>
   <script type="module">
-    import { sraInit } from 'assets/js/main.js';
-    await sraInit('how');
+    import { sraInit } from './assets/js/main.js';
+    (async () => { await sraInit('how'); })();
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
             </a>
           </div>
         </div>
-        <img src="assets/images/no background white.png" alt="Social Risk Audit logo" class="mt-10 md:mt-0 md:h-72 lg:h-96 w-auto opacity-90 md:ml-10" />
+        <img src="assets/images/no background white.png" alt="Social Risk Audit logo" class="hidden md:block h-auto w-64 sm:w-80 md:w-[28rem] lg:w-[32rem] opacity-90" />
       </div>
     </section>
   </main>
@@ -66,8 +66,8 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <script defer src="assets/js/lang-toggle.js"></script>
   <script type="module">
-    import { sraInit } from 'assets/js/main.js';
-    await sraInit('home');
+    import { sraInit } from './assets/js/main.js';
+    (async () => { await sraInit('home'); })();
   </script>
 </body>
 </html>

--- a/packages.html
+++ b/packages.html
@@ -17,10 +17,10 @@
     </section>
   </main>
   <div id="sra-footer"></div>
-  <script defer src="/assets/js/lang-toggle.js"></script>
+  <script defer src="assets/js/lang-toggle.js"></script>
   <script type="module">
-    import { sraInit } from 'assets/js/main.js';
-    await sraInit('packages');
+    import { sraInit } from './assets/js/main.js';
+    (async () => { await sraInit('packages'); })();
   </script>
 </body>
 </html>

--- a/what-you-get.html
+++ b/what-you-get.html
@@ -17,10 +17,10 @@
     </section>
   </main>
   <div id="sra-footer"></div>
-  <script defer src="/assets/js/lang-toggle.js"></script>
+  <script defer src="assets/js/lang-toggle.js"></script>
   <script type="module">
-    import { sraInit } from 'assets/js/main.js';
-    await sraInit('deliverables');
+    import { sraInit } from './assets/js/main.js';
+    (async () => { await sraInit('deliverables'); })();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load lang-toggle.js before main module and call `sraInit` via async IIFE using `./assets/js/main.js`
- ensure all pages use relative asset paths and init language toggle
- hide large home-page hero logo on extra-small screens to reduce crowding

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc924cdc84832395631f3330dbe701