### PR TITLE
Fix bilingual site paths and redirects

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="refresh" content="0; url=/en/index.html" />
+  <title>Page Not Found — Social Risk Audit</title>
+</head>
+<body>
+  <p>Not found. <a href="/en/index.html">Go to the English homepage.</a></p>
+</body>
+</html>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -12,10 +12,18 @@ function setLanguageLinks(pageKey) {
     faq: 'faq.html'
   };
   const page = map[pageKey] || 'index.html';
+  const lang = document.documentElement.lang;
   const en = document.getElementById('lang-en');
   const he = document.getElementById('lang-he');
-  if (en) en.setAttribute('href', `../en/${page}`);
-  if (he) he.setAttribute('href', `../he/${page}`);
+  if (lang === 'en') {
+    en?.classList.add('pointer-events-none', 'text-white/50');
+    en?.setAttribute('aria-current', 'page');
+    he?.setAttribute('href', `../he/${page}`);
+  } else if (lang === 'he') {
+    he?.classList.add('pointer-events-none', 'text-white/50');
+    he?.setAttribute('aria-current', 'page');
+    en?.setAttribute('href', `../en/${page}`);
+  }
 }
 
 async function mountSidebar(pageKey) {

--- a/en/ethics.html
+++ b/en/ethics.html
@@ -9,6 +9,9 @@
   <meta property="og:description" content="Consent-only, public-view audits. Human-performed, privacy-first." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="../assets/images/no background black.png" />
+  <link rel="icon" href="../assets/favicon/favicon.ico" sizes="any" />
+  <link rel="icon" href="../assets/favicon/favicon.svg" type="image/svg+xml" />
+  <link rel="manifest" href="../assets/favicon/site.webmanifest" />
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="../assets/css/styles.css" rel="stylesheet" />
 </head>

--- a/en/how.html
+++ b/en/how.html
@@ -5,6 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>How it works — Social Risk Audit</title>
   <meta property="og:image" content="../assets/images/no background black.png" />
+  <link rel="icon" href="../assets/favicon/favicon.ico" sizes="any" />
+  <link rel="icon" href="../assets/favicon/favicon.svg" type="image/svg+xml" />
+  <link rel="manifest" href="../assets/favicon/site.webmanifest" />
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="../assets/css/styles.css" rel="stylesheet" />
 </head>

--- a/en/packages.html
+++ b/en/packages.html
@@ -5,6 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Packages — Social Risk Audit</title>
   <meta property="og:image" content="../assets/images/no background black.png" />
+  <link rel="icon" href="../assets/favicon/favicon.ico" sizes="any" />
+  <link rel="icon" href="../assets/favicon/favicon.svg" type="image/svg+xml" />
+  <link rel="manifest" href="../assets/favicon/site.webmanifest" />
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="../assets/css/styles.css" rel="stylesheet" />
 </head>

--- a/en/what-you-get.html
+++ b/en/what-you-get.html
@@ -5,6 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>What you get — Social Risk Audit</title>
   <meta property="og:image" content="../assets/images/no background black.png" />
+  <link rel="icon" href="../assets/favicon/favicon.ico" sizes="any" />
+  <link rel="icon" href="../assets/favicon/favicon.svg" type="image/svg+xml" />
+  <link rel="manifest" href="../assets/favicon/site.webmanifest" />
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="../assets/css/styles.css" rel="stylesheet" />
 </head>

--- a/he/ethics.html
+++ b/he/ethics.html
@@ -9,6 +9,9 @@
   <meta property="og:description" content="בדיקות בהסכמה בלבד ובמידע ציבורי. מבוצע ידנית, פרטיות תחילה." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="../assets/images/no background black.png" />
+  <link rel="icon" href="../assets/favicon/favicon.ico" sizes="any" />
+  <link rel="icon" href="../assets/favicon/favicon.svg" type="image/svg+xml" />
+  <link rel="manifest" href="../assets/favicon/site.webmanifest" />
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="../assets/css/styles.css" rel="stylesheet" />
 </head>

--- a/he/how.html
+++ b/he/how.html
@@ -5,6 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>איך זה עובד — Social Risk Audit</title>
   <meta property="og:image" content="../assets/images/no background black.png" />
+  <link rel="icon" href="../assets/favicon/favicon.ico" sizes="any" />
+  <link rel="icon" href="../assets/favicon/favicon.svg" type="image/svg+xml" />
+  <link rel="manifest" href="../assets/favicon/site.webmanifest" />
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="../assets/css/styles.css" rel="stylesheet" />
 </head>

--- a/he/packages.html
+++ b/he/packages.html
@@ -5,6 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>חבילות — Social Risk Audit</title>
   <meta property="og:image" content="../assets/images/no background black.png" />
+  <link rel="icon" href="../assets/favicon/favicon.ico" sizes="any" />
+  <link rel="icon" href="../assets/favicon/favicon.svg" type="image/svg+xml" />
+  <link rel="manifest" href="../assets/favicon/site.webmanifest" />
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="../assets/css/styles.css" rel="stylesheet" />
 </head>

--- a/he/what-you-get.html
+++ b/he/what-you-get.html
@@ -5,6 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>מה מקבלים — Social Risk Audit</title>
   <meta property="og:image" content="../assets/images/no background black.png" />
+  <link rel="icon" href="../assets/favicon/favicon.ico" sizes="any" />
+  <link rel="icon" href="../assets/favicon/favicon.svg" type="image/svg+xml" />
+  <link rel="manifest" href="../assets/favicon/site.webmanifest" />
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="../assets/css/styles.css" rel="stylesheet" />
 </head>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="refresh" content="0; url=/en/index.html" />
+  <title>Redirecting to Social Risk Audit</title>
+</head>
+<body>
+  <p><a href="/en/index.html">Redirecting to English homepage...</a></p>
+</body>
+</html>

--- a/partials/header.html
+++ b/partials/header.html
@@ -4,8 +4,8 @@
       <img src="../assets/images/no background white.png" alt="Social Risk Audit logo" class="h-8 w-auto" />
     </a>
     <div class="flex items-center gap-3">
-      <a id="lang-en" class="text-sm font-medium">English</a>
-      <a id="lang-he" class="text-sm font-medium">עברית</a>
+      <a id="lang-en" href="../en/index.html" class="text-sm font-medium">English</a>
+      <a id="lang-he" href="../he/index.html" class="text-sm font-medium">עברית</a>
     </div>
   </div>
 </header>


### PR DESCRIPTION
## Summary
- Redirect root and 404 pages to the English homepage
- Replace runtime translation with static language links and disable current language
- Point language pages at shared ../assets and ../partials resources

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd552b5b7c8323827a0b1e084fb598